### PR TITLE
use the carrier and service_level stored from the shipment instead fo…

### DIFF
--- a/lib/hushed/documents/request/shipment_order.rb
+++ b/lib/hushed/documents/request/shipment_order.rb
@@ -43,8 +43,8 @@ module Hushed
                   xml.Comments @shipment.order.gift.message
                 end
 
-                xml.ShipMode('Carrier'      => @shipment.shipping_method.carrier,
-                             'ServiceLevel' => @shipment.shipping_method.service_level)
+                xml.ShipMode('Carrier'      => @shipment.carrier,
+                             'ServiceLevel' => @shipment.service_level)
 
                 xml.ShipTo(ship_to_hash)
                 xml.BillTo(bill_to_hash)

--- a/lib/hushed/documents/request/shipment_order.rb
+++ b/lib/hushed/documents/request/shipment_order.rb
@@ -43,8 +43,11 @@ module Hushed
                   xml.Comments @shipment.order.gift.message
                 end
 
-                xml.ShipMode('Carrier'      => @shipment.carrier,
-                             'ServiceLevel' => @shipment.service_level)
+                carrier       = @shipment.carrier || @shipment.shipping_method.carrier
+                service_level = @shipment.service_level || @shipment.shipping_method.service_level
+
+                xml.ShipMode('Carrier'      => carrier,
+                             'ServiceLevel' => service_level)
 
                 xml.ShipTo(ship_to_hash)
                 xml.BillTo(bill_to_hash)


### PR DESCRIPTION
…r are more up-to-date info

@bryanmtl there isn't really much else to add here but this since we decided to store the carrier and service_level in the shipment table.