### PR TITLE
Send Just The Warehouse Sku to Quiet

### DIFF
--- a/lib/hushed/documents/request/hash_converter.rb
+++ b/lib/hushed/documents/request/hash_converter.rb
@@ -4,7 +4,7 @@ module Hushed
       module HashConverter
         def order_details(item)
           details = {
-            'ItemNumber'      => normalize_sku(item.variant.sku),
+            'ItemNumber'      => item.variant.current_warehouse_sku,
             'UOM'             => 'EA',
             'Price'           => item.variant.price
           }
@@ -37,11 +37,6 @@ module Hushed
             'Country'    => bill_address.country.name
           }
         end
-
-        private
-          def normalize_sku(sku)
-            sku.chomp("-SET")
-          end
       end
     end
   end

--- a/spec/unit/documents/request/hash_converter_spec.rb
+++ b/spec/unit/documents/request/hash_converter_spec.rb
@@ -19,13 +19,6 @@ module Hushed
           assert_equal "EA", hash['UOM']
           assert_equal 9.95, hash['Price']
         end
-
-        it "strip the postfix '-SET' from the sku" do
-          item = InventoryUnitDouble.example(variant: VariantDouble.example(sku: "ABC-SET"))
-
-          assert_equal "ABC", order_details(item)['ItemNumber']
-        end
-
       end
     end
   end


### PR DESCRIPTION
No longer worry about sets or skus being incorrectly formatted. The
variant will have knowledge of the most recent warehouse sku and we
should send this down, or up to Quiet. Main PR linked below. This will
need to be merged into the support-physical-card branch when that PR is
closed.

GitHub:
https://github.com/glossier/glossier-v2/pull/1750