### PR TITLE
use state_name in rare cases that state_id is nil, this will prevent …

### DIFF
--- a/lib/hushed/documents/request/hash_converter.rb
+++ b/lib/hushed/documents/request/hash_converter.rb
@@ -19,7 +19,7 @@ module Hushed
             'Address1'   => ship_address.address1,
             'Address2'   => ship_address.address2,
             'City'       => ship_address.city,
-            'State'      => ship_address.state.name,
+            'State'      => state(ship_address),
             'PostalCode' => ship_address.zipcode,
             'Country'    => ship_address.country.name
           }
@@ -32,7 +32,7 @@ module Hushed
             'Address1'   => bill_address.address1,
             'Address2'   => bill_address.address2,
             'City'       => bill_address.city,
-            'State'      => bill_address.state.name,
+            'State'      => state(bill_address),
             'PostalCode' => bill_address.zipcode,
             'Country'    => bill_address.country.name
           }
@@ -41,6 +41,10 @@ module Hushed
         private
           def normalize_sku(sku)
             sku.chomp("-SET")
+          end
+
+          def state(address)
+            address.state ? address.state.name : address.state_name
           end
       end
     end


### PR DESCRIPTION
…the exception

@bryanmtl not exactly sure if this is worth the change - there are only 2 cases of this happening but i can't push the shipment to Quiet because it will cause an exception if state id is nil.

![image](https://cloud.githubusercontent.com/assets/175045/24548174/67e516ca-1646-11e7-923b-56a8310f2626.png)
